### PR TITLE
ork: fix typo in Green Tide secondary objective category

### DIFF
--- a/9e/factions.json
+++ b/9e/factions.json
@@ -599,7 +599,7 @@
 					]
 				},
 				{
-					"name": "Green Tide",
+					"name": "Battlefield Supremacy",
 					"objectives": [
 						{
 							"id": "EW.14.04.01",


### PR DESCRIPTION
fix #2 